### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var path = require('path');
 var ejs = require('ejs');
 var SignedXml = require('xml-crypto').SignedXml;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var wsseSecurityHeaderTemplate = ejs.compile(fs.readFileSync(path.join(__dirname, 'templates', 'wsse-security-header.ejs')).toString());
 var wsseSecurityTokenTemplate = ejs.compile(fs.readFileSync(path.join(__dirname, 'templates', 'wsse-security-token.ejs')).toString());
 

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   "author": "hujb2000 <hujb2000@163.com>",
   "dependencies": {
     "debug": "~0.7.4",
+    "ejs": "~2.3.4",
     "lodash": "3.x.x",
     "request": ">=2.9.0",
     "sax": ">=0.6",
     "selectn": "^0.9.6",
     "strip-bom": "~0.3.1",
     "ursa": "0.8.5 || >=0.9.3",
-    "node-uuid": "~1.4.3",
-    "ejs": "~2.3.4",
+    "uuid": "^3.0.0",
     "xml-crypto": "~0.8.0"
   },
   "repository": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.